### PR TITLE
Add skills directory with CLI and Node module documentation

### DIFF
--- a/skills/exifremove/SKILL.md
+++ b/skills/exifremove/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: exifremove
+version: 1.0.1
+description: Remove EXIF metadata from JPEG images. Use when working with JPEG files that contain metadata to be stripped, processing images for privacy, or automating EXIF removal in Node.js scripts or pipelines. Triggers include "exifremove", "remove exif", "strip exif", "strip metadata", "jpeg metadata", "image metadata removal".
+metadata:
+  short-description: Strip EXIF metadata from JPEG images
+  compatibility: claude-code
+---
+
+# exifremove
+
+`exifremove` strips EXIF metadata from JPEG images by operating directly on the raw bytes of the file. It locates and removes APP1 segments (the standard carrier for EXIF data) without re-encoding the image, so there is no quality loss.
+
+Two usage modes are available:
+
+| Mode | Package | When to use |
+|------|---------|-------------|
+| **CLI** | `exifremove-cli` | One-off file processing, shell scripts |
+| **Node module** | `exifremove` | Programmatic use inside a Node.js application |
+
+## Installation
+
+**CLI (global):**
+```bash
+npm install -g exifremove-cli
+```
+
+**Node module:**
+```bash
+npm install exifremove
+```
+
+## Quick Examples
+
+**CLI — strip a single file:**
+```bash
+exifremove photo.jpg
+# writes photo.modified.jpg
+```
+
+**Node module — strip from a buffer:**
+```js
+const { remove } = require('exifremove');
+const fs = require('fs');
+
+const input = fs.readFileSync('photo.jpg');
+const output = remove(input);
+fs.writeFileSync('photo.modified.jpg', output);
+```
+
+## References
+
+- [cli](rules/cli.md) — CLI flags, output naming, and examples
+- [node](rules/node.md) — Node module API, options, and TypeScript types

--- a/skills/exifremove/rules/cli.md
+++ b/skills/exifremove/rules/cli.md
@@ -1,0 +1,75 @@
+# exifremove CLI
+
+The CLI processes one or more JPEG files and writes the EXIF-stripped results to new files alongside the originals. It accepts only `.jpg` and `.jpeg` files (case-insensitive).
+
+## Installation
+
+```bash
+npm install -g exifremove-cli
+```
+
+## Usage
+
+```
+exifremove [image0] ... [imageN]
+```
+
+## Flags
+
+| Flag | Short | Type | Description |
+|------|-------|------|-------------|
+| `--verbose` | `-v` | count | Print processing details. Pass twice (`-vv`) for raw buffer output. |
+| `--keep-marker` | `--km` | boolean | Keep the APP1 marker in place with a zeroed size, rather than removing the entire segment. |
+| `--version` | | boolean | Print the installed version. |
+| `--help` | `-h` | boolean | Show help. |
+
+## Output Naming
+
+For each input file, a new file is written with `modified` inserted before the extension:
+
+```
+photo.jpg         →  photo.modified.jpg
+portrait.jpeg     →  portrait.modified.jpeg
+shots/img001.jpg  →  shots/img001.modified.jpg
+```
+
+The original file is not modified.
+
+## Examples
+
+**Single file:**
+```bash
+exifremove photo.jpg
+# File written successfully.
+```
+
+**Multiple files:**
+```bash
+exifremove img001.jpg img002.jpg img003.jpg
+```
+
+**Verbose output — see what the processor is doing:**
+```bash
+exifremove -v photo.jpg
+# Processing 'photo.jpg'
+# Image file length: 349028
+# APP1 start
+# offset in hex: 12f4
+# offset in decimal: 4852
+# Writing EXIF-stripped image file to 'photo.modified.jpg'...
+# File written successfully.
+```
+
+**Keep the APP1 marker (zero out EXIF size instead of removing the segment):**
+```bash
+exifremove --km photo.jpg
+```
+
+## Error Behavior
+
+| Condition | Output | Exit code |
+|-----------|--------|-----------|
+| No files supplied | `No images supplied` → stderr | 1 |
+| File is not `.jpg` / `.jpeg` | `'file.png' is not a JPEG.` → stderr | 1 |
+| File does not exist | `Error opening 'file.jpg'. Image file does not exist.` → stdout | 1 |
+| Unknown file open error | `Unknown error opening 'file.jpg'. Error code: <code>` → stdout | 1 |

--- a/skills/exifremove/rules/node.md
+++ b/skills/exifremove/rules/node.md
@@ -1,0 +1,161 @@
+# exifremove Node Module
+
+The Node module exposes two functions that operate on `Buffer` or `Uint8Array` objects. It has zero runtime dependencies.
+
+## Installation
+
+```bash
+npm install exifremove
+```
+
+TypeScript types are included at `src/exifremove.d.ts` — no `@types/` package is needed.
+
+## Import
+
+```js
+// CommonJS
+const { remove, removeMultiple } = require('exifremove');
+```
+
+```ts
+// TypeScript
+import { remove, removeMultiple, RemoveOptions } from 'exifremove';
+```
+
+## API
+
+### `remove(imageBuffer, options?)`
+
+Strips EXIF data from a single JPEG image buffer.
+
+```ts
+function remove(
+    imageBuffer: Uint8Array | Buffer,
+    options?: RemoveOptions,
+): Buffer | undefined;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `imageBuffer` | `Uint8Array \| Buffer` | Raw bytes of the JPEG image |
+| `options` | `RemoveOptions` | Optional. See [Options](#options). |
+
+**Returns:** A new `Buffer` with the EXIF data removed, or `undefined` if `imageBuffer` is `undefined`, `null`, or fewer than 2 bytes.
+
+**Throws:** `Error('Not a JPEG')` if the buffer does not start with the JPEG SOI marker (`0xFFD8`).
+
+---
+
+### `removeMultiple(imageBuffers, options?)`
+
+Strips EXIF data from an array of JPEG image buffers.
+
+```ts
+function removeMultiple(
+    imageBuffers: Array<Uint8Array | Buffer>,
+    options?: RemoveOptions,
+): Array<Buffer | undefined>;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `imageBuffers` | `Array<Uint8Array \| Buffer>` | Array of raw image buffers |
+| `options` | `RemoveOptions` | Optional. See [Options](#options). |
+
+**Returns:** An array of `Buffer | undefined` values, one per input, in the same order.
+
+---
+
+### Options
+
+```ts
+interface RemoveOptions {
+    verbose?: boolean;
+    keepMarker?: boolean;
+}
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `verbose` | `boolean` | `false` | Log APP1 offset details to `console.log` during processing. |
+| `keepMarker` | `boolean` | `false` | Instead of removing the APP1 segment entirely, keep the marker bytes and set the segment size to `0x0002` (effectively empty). Useful when downstream tools expect the APP1 marker to be present. |
+
+## Examples
+
+**Read a file, strip EXIF, write result:**
+```js
+const { remove } = require('exifremove');
+const fs = require('fs');
+
+const input = fs.readFileSync('photo.jpg');
+const output = remove(input);
+fs.writeFileSync('photo.modified.jpg', output);
+```
+
+**Handle non-JPEG input gracefully:**
+```js
+const { remove } = require('exifremove');
+
+function tryRemove(buffer) {
+    try {
+        return remove(buffer);
+    } catch (err) {
+        if (err.message === 'Not a JPEG') {
+            console.error('Skipping: not a JPEG file');
+            return null;
+        }
+        throw err;
+    }
+}
+```
+
+**Process multiple files:**
+```js
+const { removeMultiple } = require('exifremove');
+const fs = require('fs');
+
+const paths = ['img001.jpg', 'img002.jpg', 'img003.jpg'];
+const buffers = paths.map((p) => fs.readFileSync(p));
+const results = removeMultiple(buffers);
+
+results.forEach((result, i) => {
+    if (result) {
+        const dest = paths[i].replace('.jpg', '.modified.jpg');
+        fs.writeFileSync(dest, result);
+    }
+});
+```
+
+**Keep the APP1 marker (zero out EXIF instead of removing the segment):**
+```js
+const { remove } = require('exifremove');
+const fs = require('fs');
+
+const input = fs.readFileSync('photo.jpg');
+const output = remove(input, { keepMarker: true });
+fs.writeFileSync('photo.modified.jpg', output);
+```
+
+**TypeScript — typed options:**
+```ts
+import { remove, RemoveOptions } from 'exifremove';
+import { readFileSync, writeFileSync } from 'fs';
+
+const options: RemoveOptions = { keepMarker: true, verbose: false };
+const input = readFileSync('photo.jpg');
+const output = remove(input, options);
+if (output) {
+    writeFileSync('photo.modified.jpg', output);
+}
+```
+
+## Behavior Notes
+
+- `remove()` does not re-encode the image. It splices raw bytes, so there is no quality loss.
+- Only APP1 segments are removed. Other JPEG markers (JFIF APP0, ICC profiles, etc.) are left untouched unless they also appear in APP1.
+- Scanning stops at the SOS marker (`0xFFDA`), which marks the start of actual image data. No EXIF segments appear after that point in a well-formed JPEG.
+- Images that have no EXIF data pass through unchanged.


### PR DESCRIPTION
Adds skills/exifremove/ with a top-level SKILL.md entry point and two
rule files covering the CLI (flags, output naming, error behavior) and
the Node module (remove/removeMultiple API, options, TypeScript usage).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>